### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template, request, session, jsonify
 import getdata 
 import json 
+import os
 
 # Run Self Tests
 print("Checking Dependecies")
@@ -233,4 +234,5 @@ def samplejson():
     return render_template('sampleresponse.json')
 
 if __name__ == "__main__":
-    app.run(debug=True, port=44751)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode, port=44751)


### PR DESCRIPTION
Potential fix for [https://github.com/Darbyshire64/FuelHound/security/code-scanning/1](https://github.com/Darbyshire64/FuelHound/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Modify the `app.run` call to use an environment variable to determine whether to run in debug mode.
2. Import the `os` module to access environment variables.
3. Set the default value of the debug mode to `False` to ensure it is disabled if the environment variable is not set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
